### PR TITLE
MCD-56 Address render and navigation bugs

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,5 +1,12 @@
-// Anchor link bug encountered when updating from Gatsby v4 to v5
-// Solution adapted from https://github.com/gatsbyjs/gatsby/issues/21120#issuecomment-581141246
+/*
+ * Anchor link bug encountered when updating from Gatsby v4 to v5
+ *
+ * TS solutions adapted from
+ * https://github.com/gatsbyjs/gatsby/issues/21120#issuecomment-581141246
+ * and
+ * https://github.com/gatsbyjs/gatsby/issues/25778#issuecomment-734067757
+ *
+ */
 
 interface LocationProps {
   location: {
@@ -7,20 +14,24 @@ interface LocationProps {
   };
 }
 
-interface ElementProps extends Element {
+interface TargetElementProps extends Element {
   offsetTop: number;
 }
 
 const scrollToAnchor = (location: { hash: string }) => {
   if (location && location.hash) {
-    const element: ElementProps | null = document.querySelector(location.hash);
+    const targetElement: TargetElementProps | null = document.querySelector(
+      location.hash,
+    );
 
-    if (element) {
+    if (targetElement) {
       window.scrollTo({
-        top: element.offsetTop,
+        top: targetElement.offsetTop,
         behavior: "smooth",
       });
     }
+  } else {
+    window.scrollTo(0, 0);
   }
 
   return true;


### PR DESCRIPTION
- Adjust code in gatsby browser to scroll to page top when hashes are not present